### PR TITLE
fix unit test: sbt is currently not included in Ubuntu 24.04.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   jdk-version:
     required: false
     description: 'jdk version'
-    default: '8'
+    default: '11'
 
 runs:
   using: "composite"
@@ -28,6 +28,7 @@ runs:
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.jdk-version }}
+    - uses: sbt/setup-sbt@v1
 
     - name: SBT Cache
       uses: actions/cache@v4


### PR DESCRIPTION
The Runner Image team has made cuts to the list of included packages in order to maintain our SLA for free disk space. More details here: actions/runner-images#10636.