### PR TITLE
fix: bump actions a Node 24 (checkout@v6 / setup-java@v5 / cache@v6)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,20 +18,20 @@ runs:
   using: "composite"
   steps:
     - name: Clone Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         token: ${{ inputs.token }}
 
     - name: Set up JDK ${{ inputs.jdk-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.jdk-version }}
     - uses: sbt/setup-sbt@v1
 
     - name: SBT Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.sbt

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Set up JDK ${{ inputs.jdk-version }}
       uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ inputs.jdk-version }}
     - uses: sbt/setup-sbt@v1
 


### PR DESCRIPTION
## Contexto

Closes #127.

El composite `action_checkout_jdk_sbt-cache` —usado por todos los workflows Scala reusables de `BQN-UY/CI-CD` (`scala-ci`, `scala-make-release-jar`, `scala-deploy-jar`) en su step "Checkout / Setup JDK / sbt-cache"— pineaba tres actions sobre Node 20 (deprecado). El cierre original de #127 audito solo archivos dentro del repo CI-CD y dejo afuera este composite, por lo que el warning seguia apareciendo en cada consumidor.

Detectado en el `make-release` de bol-api v1.3.0 (run 28383677065).

## Cambio

| Action | Antes | Despues | Runtime verificado |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | node24 (ya validado en acp-api) |
| `actions/setup-java` | `@v4` | `@v5` | node24 |
| `actions/cache` | `@v4` | `@v6` | node24 |

`sbt/setup-sbt@v1` queda igual (no figura en el warning).

## Validacion

Al estar pineado en `@main`, los consumidores lo heredan al mergear. Plan: tras merge, correr CI de un consumidor (bol-api) y confirmar que desaparece la anotacion de Node 20.

## Deadline

`2026-09-16`: Node 20 removido del runner (sin escape hatch).